### PR TITLE
add MaxFallbackPoStChallengeCount

### DIFF
--- a/pkg/params/constants.go
+++ b/pkg/params/constants.go
@@ -6,6 +6,8 @@ package params
 // 1 / n
 const SectorChallengeRatioDiv = 25
 
+const MaxFallbackPostChallengeCount = 10
+
 // /////
 // Devnet settings
 


### PR DESCRIPTION
## Why does this PR exist?

The new shared stuff generates a fallback PoSt. To do this, we need `MaxFallbackPoStChallengeCount` (which is shared with other parts of lotus).

## What's in this PR?

We move the constant. That's really it. Great, eh?